### PR TITLE
Check color space referring to device-dependent color space

### DIFF
--- a/pdf2docx/common/pdf.py
+++ b/pdf2docx/common/pdf.py
@@ -573,12 +573,16 @@ def _check_device_cs(page:fitz.Page):
         elif line=='>>':
             break
 
-        # now within cs block, e.g. /Cs6 14 0 R
-        try:
-            cs_name, xref, *_ = line.split()
-            cs[cs_name] = _is_device_cs(int(xref), doc)
-        except:
-            pass
+        # now within cs block
+        cs_name, xref, *_ = line.split()
+
+        # check color space referring to device-dependent color space, e.g. /CSp /DeviceRGB
+        if xref in cs:
+            cs[cs_name] = cs[xref]
+            continue
+
+        # check color space definition array, e.g. /Cs6 14 0 R
+        cs[cs_name] = _is_device_cs(int(xref), doc)
 
     return cs
 

--- a/pdf2docx/common/pdf.py
+++ b/pdf2docx/common/pdf.py
@@ -574,8 +574,11 @@ def _check_device_cs(page:fitz.Page):
             break
 
         # now within cs block, e.g. /Cs6 14 0 R
-        cs_name, xref, *_ = line.split()
-        cs[cs_name] = _is_device_cs(int(xref), doc)
+        try:
+            cs_name, xref, *_ = line.split()
+            cs[cs_name] = _is_device_cs(int(xref), doc)
+        except:
+            pass
 
     return cs
 


### PR DESCRIPTION
This is a workaround for #49. It fixes the ValueError, but it doesn't fix black background of the image.

Currently, errors are just ignored, but the other possibility can be to instead trigger warning, which will inform users that something is wrong but won't cause stop of execution.

I don't know PDF specification so I don't know how `/CSp /DeviceRGB` should be interpreted. If it means that `CSp` should be "alias" to `DeviceRGB`, which means `CSp` is also device CS, this could be done with checking if `cs_name` (`/DeviceRGB`) is already in `cs` and setting `cs[cs_name]` (`/CSp`) to true, without calling `_is_device_cs` and converting `xref` to int. However, I don't know if this is correct and if it will solve the background issue.