### PR TITLE
Fix wrong attribute name

### DIFF
--- a/pdf2docx/page/RawPageFitz.py
+++ b/pdf2docx/page/RawPageFitz.py
@@ -40,7 +40,7 @@ class RawPageFitz(RawPage):
         raw_dict['shapes'].extend(hyperlinks)        
        
         # Element is a base class processing coordinates, so set rotation matrix globally
-        Element.set_rotation_matrix(self.page_engine.rotationMatrix)
+        Element.set_rotation_matrix(self.page_engine.rotation_matrix)
 
         return raw_dict
     


### PR DESCRIPTION
In line 43 "Element.set_rotation_matrix(self.page_engine.rotationMatrix)" is wrong and causes an error because the attribute name is "rotation_matrix" but inside the parentheses it is written as "rotationMatrix". The line should be changed to "Element.set_rotation_matrix(self.page_engine.rotation_matrix)"