### PR TITLE
Don't crash app on convert error.

### DIFF
--- a/pdf2docx/common/share.py
+++ b/pdf2docx/common/share.py
@@ -158,8 +158,11 @@ def rgb_component(srgb:int):
         [int(255*x) for x in fitz.sRGB_to_pdf(x)]
     '''
     # decimal to hex: 0x...
-    s = hex(srgb)[2:].zfill(6)
-    return [int(s[i:i+2], 16) for i in [0, 2, 4]]
+    try:
+        s = hex(srgb)[2:].zfill(6)
+        return [int(s[i:i+2], 16) for i in [0, 2, 4]]
+    except Exception as e:
+        return [0, 0, 0]
 
 
 def rgb_to_value(rgb:list):


### PR DESCRIPTION
I have no idea what values we can choose as dummy, but let's doing the job!

```bash
File "pdf2docx/common/share.py", line 162, in <listcomp>
    return [int(s[i:i+2], 16) for i in [0, 2, 4]]
            ^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 16: 'xe'
```